### PR TITLE
Separate cache and response from main

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepe"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Omar MHAIMDAT"]
 edition = "2021"
 description = "HTTP load generator and performance testing tool"
@@ -30,10 +30,17 @@ indicatif = "0.17"
 curl-parser = { "git" = "https://github.com/omarmhaimdat/curl-parser" }
 
 [profile.release]
-opt-level = "z"
-lto = "fat"
+opt-level = 3
+lto = true
 codegen-units = 1
-strip = "symbols"
+panic = "abort"
+strip = true
+debug = false
+
+[profile.release.package."*"]
+opt-level = 3
+debug = false
+strip = true
 
 [[bin]]
 name = "pepe"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,89 @@
+use hyper::HeaderMap;
+
+
+const CACHE_HEADERS: [&str; 7] = [
+    "x-cache",
+    "x-cache-status",
+    "cf-cache-status",
+    "x-cache-lookup",
+    "x-cdn-cache-status",
+    "x-backend-cache-status",
+    "x-vercel-cache",
+];
+
+// CacheStatus is an enum that represents the status of a cache
+// These values are extracted from the cache headers of a response
+// The values are used to determine if a response was served from cache
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum CacheStatus {
+    Hit,
+    Miss,
+    Stale,
+    Expired,
+    Revalidated,
+    Bypass,
+    Dynamic,
+    Error,
+    Unknown,
+}
+
+
+// CacheCategory is an enum that represents the category of a cache status
+// Some cache statuses are grouped into categories to simplify the analysis
+#[derive(Hash, Debug, PartialEq, Eq, Clone)]
+pub enum CacheCategory {
+    Hit,
+    Miss,
+    Unknown,
+}
+
+impl CacheCategory {
+    pub fn from_cache_status(status: &CacheStatus) -> CacheCategory {
+        match status {
+            CacheStatus::Hit | CacheStatus::Revalidated | CacheStatus::Stale => CacheCategory::Hit,
+            CacheStatus::Miss
+            | CacheStatus::Expired
+            | CacheStatus::Bypass
+            | CacheStatus::Dynamic => CacheCategory::Miss,
+            CacheStatus::Error | CacheStatus::Unknown => CacheCategory::Unknown,
+        }
+    }
+}
+
+impl CacheStatus {
+    // Parse a cache status value string into the CacheStatus enum
+    pub fn from_str(status: &str) -> CacheStatus {
+        match status.to_lowercase().as_str() {
+            "hit" => CacheStatus::Hit,
+            "miss" => CacheStatus::Miss,
+            "stale" => CacheStatus::Stale,
+            "expired" => CacheStatus::Expired,
+            "revalidated" => CacheStatus::Revalidated,
+            "bypass" => CacheStatus::Bypass,
+            "dynamic" => CacheStatus::Dynamic,
+            "error" => CacheStatus::Error,
+            _ => CacheStatus::Unknown,
+        }
+    }
+
+    pub fn _to_category(&self) -> CacheCategory {
+        CacheCategory::from_cache_status(self)
+    }
+
+
+    /// Parse cache headers into a CacheStatus enum
+    /// This function is not exhaustive and only supports a few cache headers
+    pub fn parse_headers(headers: &HeaderMap) -> Option<CacheStatus> {
+        
+
+        for header in CACHE_HEADERS.iter() {
+            if let Some(value) = headers.get(*header) {
+                if let Ok(value_str) = value.to_str() {
+                    return Some(CacheStatus::from_str(value_str));
+                }
+            }
+        }
+
+        None
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,225 @@
+use clap::{ArgAction::HelpLong, Error, Parser};
+use curl_parser;
+use reqwest::{header::USER_AGENT, Proxy};
+
+use crate::utils::{default_user_agent, num_of_cores, version};
+use crate::PepeError;
+
+#[derive(Parser, Debug, Clone)]
+#[command(name = "pepe")]
+#[command(version = version())]
+#[command(about = "HTTP load generator")]
+#[clap(disable_help_flag = true)]
+pub struct Cli {
+    #[arg(short, long, action = HelpLong)]
+    pub help: Option<bool>,
+
+    /// Number of requests to perform
+    #[arg(short, long, default_value_t = 100)]
+    pub number: u32,
+
+    /// Number of concurrent requests at a time
+    #[arg(short, long, default_value_t = num_of_cores())]
+    pub concurrency: u32,
+
+    // TODO: Implement duration
+    /// Duration of the test, e.g. 10s, 3m, 2h
+    #[arg(short = 'z', long)]
+    pub duration: Option<String>,
+
+    /// Curl mode to parse curl command, e.g. pepe --curl -- 'curl -X POST http://localhost:8080'
+    #[arg(short, long)]
+    pub curl: bool,
+
+    /// HTTP method, e.g. GET, POST, PUT, DELETE
+    #[arg(short, long, default_value_t = String::from("GET"))]
+    pub method: String,
+
+    /// HTTP headers, e.g. -H 'Accept: application/json'
+    #[arg(short = 'H', long)]
+    pub headers: Vec<String>,
+
+    /// Time in seconds to wait for a response
+    #[arg(short, long, default_value_t = 20)]
+    pub timeout: u32,
+
+    /// HTTP request body
+    #[arg(short = 'd', long)]
+    pub body: Option<String>,
+
+    /// User-Agent string, default is pepe/{version}
+    #[arg(short, long, default_value_t = default_user_agent())]
+    pub user_agent: String,
+
+    /// Proxy server URL: http://user:pass@host:port or socks5://host:port
+    #[arg(short, long)]
+    pub proxy: Option<String>,
+
+    /// Disable HTTP compression, e.g. gzip
+    #[arg(long)]
+    pub disable_compression: bool,
+
+    /// Disable HTTP keepalive, e.g. Connection: close
+    #[arg(long)]
+    pub disable_keepalive: bool,
+
+    /// Prevent http redirects
+    #[arg(long)]
+    pub disable_redirects: bool,
+
+    /// HTTP url to request
+    #[arg(default_value_t = String::from(""))]
+    pub url: String,
+
+    /// List of arguments to pass to curl command
+    #[arg(last = true, default_value = "")]
+    pub args: Vec<String>,
+}
+
+impl Cli {
+    pub fn validate(&mut self) -> Result<(), Error> {
+        if self.concurrency > self.number {
+            eprintln!(
+                "Error: Number of workers cannot be smaller than the number of requests. -c {} -n {}",
+                self.concurrency, self.number
+            );
+            return Err(Error::raw(
+                clap::error::ErrorKind::ValueValidation,
+                format!(
+                    "Number of workers cannot be smaller than the number of requests. -c {} -n {}",
+                    self.concurrency, self.number
+                ),
+            ));
+        }
+
+        if self.curl == false && self.url.is_empty() {
+            return Err(Error::raw(
+                clap::error::ErrorKind::ValueValidation,
+                "URL is required",
+            ));
+        }
+
+        if self.timeout == 0 || self.timeout > 120 {
+            return Err(Error::raw(
+                clap::error::ErrorKind::ValueValidation,
+                "Timeout must be between 1 and 120 seconds",
+            ));
+        }
+
+        if self.curl {
+            // Print the curl command
+            let curl_command = self
+                .args
+                .iter()
+                .map(|arg| {
+                    if arg.contains(' ') || arg.contains('{') {
+                        format!("'{}'", arg)
+                    } else {
+                        arg.clone()
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(" ");
+            let parsed_request = curl_parser::ParsedRequest::load(&curl_command, Some(()));
+            if parsed_request.is_err() {
+                eprintln!("Error: {}", parsed_request.err().unwrap());
+                std::process::exit(1);
+            }
+            self.method = parsed_request.as_ref().unwrap().method.clone().to_string();
+            self.url = parsed_request.as_ref().unwrap().url.clone().to_string();
+            self.headers = parsed_request
+                .as_ref()
+                .unwrap()
+                .headers
+                .clone()
+                .iter()
+                .map(|(k, v)| format!("{}: {}", k, v.to_str().unwrap()))
+                .collect();
+            self.body = Some(parsed_request.as_ref().unwrap().body.clone().join(" "));
+            // print body
+            if let Some(body) = &self.body {
+                println!("Body: {}", body);
+            }
+        }
+
+        let method = reqwest::Method::from_bytes(self.method.as_bytes());
+        if !method.is_ok() {
+            return Err(Error::raw(
+                clap::error::ErrorKind::ValueValidation,
+                format!("Invalid method: {}", self.method),
+            ));
+        }
+
+        if self.proxy.is_some() {
+            if self.proxy.as_ref().unwrap().starts_with("socks4") {
+                return Err(Error::raw(
+                    clap::error::ErrorKind::ValueValidation,
+                    "Socks4 proxy is not supported by reqwest.",
+                ));
+            }
+            let proxy = Proxy::all(self.proxy.as_ref().unwrap());
+            if proxy.is_err() {
+                return Err(Error::raw(
+                    clap::error::ErrorKind::ValueValidation,
+                    format!("Invalid proxy URL: {}", self.proxy.as_ref().unwrap()),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn build_client(&self) -> Result<reqwest::Client, PepeError> {
+        let mut request_headers = reqwest::header::HeaderMap::new();
+
+        // Add user agent
+        request_headers.insert(
+            USER_AGENT,
+            self.user_agent
+                .parse::<reqwest::header::HeaderValue>()
+                .map_err(|e| PepeError::HeaderParseError(e.to_string()))?,
+        );
+
+        // Parse headers safely
+        for header in &self.headers {
+            let parts: Vec<&str> = header.splitn(2, ':').collect();
+            if parts.len() == 2 {
+                let name = reqwest::header::HeaderName::from_bytes(parts[0].trim().as_bytes())
+                    .map_err(|e| PepeError::HeaderParseError(e.to_string()))?;
+                let value = reqwest::header::HeaderValue::from_str(parts[1].trim())
+                    .map_err(|e| PepeError::HeaderParseError(e.to_string()))?;
+                request_headers.insert(name, value);
+            }
+        }
+
+        let mut client_builder = reqwest::Client::builder()
+            .default_headers(request_headers)
+            .timeout(std::time::Duration::from_secs(self.timeout as u64));
+
+        if let Some(proxy_url) = &self.proxy {
+            let proxy =
+                Proxy::all(proxy_url).map_err(|e| PepeError::HeaderParseError(e.to_string()))?;
+            client_builder = client_builder.proxy(proxy);
+        }
+
+        if self.disable_compression {
+            client_builder = client_builder.no_gzip();
+        }
+
+        if self.disable_keepalive {
+            client_builder = client_builder.connection_verbose(true);
+        }
+
+        if self.disable_redirects {
+            client_builder = client_builder.redirect(reqwest::redirect::Policy::none());
+        }
+
+        client_builder =
+            client_builder.timeout(std::time::Duration::from_secs(self.timeout as u64));
+
+        let client: reqwest::Client = client_builder
+            .build()
+            .map_err(|e| PepeError::RequestError(e))?;
+
+        Ok(client)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,201 +1,30 @@
-use clap::{ArgAction::HelpLong, Parser};
+use std::io::stdout;
+use std::sync::Arc;
+
+use clap::Parser;
 use crossterm::{
     cursor::Show,
     event::KeyCode,
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, LeaveAlternateScreen},
 };
-use curl_parser;
-use hyper::{HeaderMap, Uri};
-use reqwest::{header::USER_AGENT, Proxy};
-use std::io::stdout;
-use std::str::FromStr;
-use std::sync::Arc;
-use std::{num::NonZeroUsize, thread::available_parallelism};
 use tokio::sync::{mpsc, Semaphore};
 
+use crate::response::ResponseStats;
+use crate::utils::resolve_dns;
+use cli::Cli;
+
+mod cache;
+mod cli;
+mod response;
 mod ui;
-
-#[derive(Parser, Debug, Clone)]
-#[command(name = "pepe")]
-#[command(version = env!("CARGO_PKG_VERSION"))]
-#[command(about = "HTTP load generator")]
-// #[command(long_about = USAGE)]
-#[clap(disable_help_flag = true)]
-struct Args {
-    #[arg(short, long, action = HelpLong)]
-    help: Option<bool>,
-    #[clap(short = 'n', long, default_value = "100", help = "Number of requests")]
-    number: u32,
-    #[clap(short = 'c', long, default_value_t = default_concurrency(), help = "Number of concurrent requests")]
-    concurrency: u32,
-    #[clap(
-        short = 'q',
-        long,
-        default_value = "0",
-        help = "Number of requests to perform before exiting"
-    )]
-    rate_limit: u32,
-    #[clap(short = 'z', long)]
-    duration: Option<String>,
-    #[clap(short = 'o', long)]
-    output: Option<String>,
-    #[clap(
-        long = "curl",
-        help = "Curl mode to parse curl command, e.g. pepe --curl -- 'curl -X POST http://localhost:8080'"
-    )]
-    curl: bool,
-    #[clap(
-        short = 'm',
-        long,
-        default_value = "GET",
-        help = "HTTP method, e.g. GET, POST, PUT, DELETE"
-    )]
-    method: String,
-    #[clap(
-        short = 'H',
-        long,
-        help = "HTTP headers, e.g. -H 'Accept: application/json'"
-    )]
-    headers: Vec<String>,
-    #[clap(
-        short = 't',
-        long,
-        default_value = "20",
-        help = "Time in seconds to wait for a response"
-    )]
-    timeout: u32,
-    #[clap(short = 'A', long)]
-    accept: Option<String>,
-    #[clap(short = 'd', long)]
-    body: Option<String>,
-    #[clap(short = 'D', long)]
-    body_file: Option<String>,
-    #[clap(short = 'T', long, default_value = "text/html")]
-    content_type: String,
-    #[clap(short, long, default_value = concat!("pepe/", env!("CARGO_PKG_VERSION")), help = "User-Agent string, default is pepe/{version}")]
-    user_agent: String,
-    #[clap(short, long)]
-    basic_auth: Option<String>,
-    #[clap(
-        short,
-        long,
-        help = "Proxy server URL: http://user:pass@host:port or socks5://host:port"
-    )]
-    proxy: Option<String>,
-    #[clap(short, long)]
-    host: Option<String>,
-    #[clap(long)]
-    disable_compression: bool,
-    #[clap(long)]
-    disable_keepalive: bool,
-    #[clap(long)]
-    disable_redirects: bool,
-    #[clap(default_value = "", help = "URL to request")]
-    url: String,
-    #[clap(last = true, default_value = "")]
-    args: Vec<String>,
-}
-
-fn default_concurrency() -> u32 {
-    available_parallelism()
-        .unwrap_or(NonZeroUsize::new(8).unwrap())
-        .get() as u32
-}
-impl Args {
-    fn validate(&mut self) {
-        if self.concurrency > self.number {
-            eprintln!(
-                "Error: Number of workers cannot be smaller than the number of requests. -c {} -n {}",
-                self.concurrency, self.number
-            );
-            std::process::exit(1);
-        }
-
-        if self.curl == false && self.url.is_empty() {
-            eprintln!("Error: URL cannot be empty.");
-            std::process::exit(1);
-        }
-
-        // Verify Timeout
-        if self.timeout == 0 || self.timeout > 120 {
-            eprintln!("Error: Timeout cannot be 0, or greater than 120 seconds.");
-            std::process::exit(1);
-        }
-
-        if self.curl {
-            // Print the curl command
-            let curl_command = self
-                .args
-                .iter()
-                .map(|arg| {
-                    if arg.contains(' ') || arg.contains('{') {
-                        format!("'{}'", arg)
-                    } else {
-                        arg.clone()
-                    }
-                })
-                .collect::<Vec<_>>()
-                .join(" ");
-            let parsed_request = curl_parser::ParsedRequest::load(&curl_command, Some(()));
-            if parsed_request.is_err() {
-                eprintln!("Error: {}", parsed_request.err().unwrap());
-                std::process::exit(1);
-            }
-            self.method = parsed_request.as_ref().unwrap().method.clone().to_string();
-            self.url = parsed_request.as_ref().unwrap().url.clone().to_string();
-            self.headers = parsed_request
-                .as_ref()
-                .unwrap()
-                .headers
-                .clone()
-                .iter()
-                .map(|(k, v)| format!("{}: {}", k, v.to_str().unwrap()))
-                .collect();
-            self.body = Some(parsed_request.as_ref().unwrap().body.clone().join(" "));
-            // print body
-            if let Some(body) = &self.body {
-                println!("Body: {}", body);
-            }
-        }
-
-        // Check if method is valid
-        let method = reqwest::Method::from_bytes(self.method.as_bytes());
-        if !method.is_ok() {
-            eprintln!("Error: Invalid method: {}", self.method);
-            std::process::exit(1);
-        }
-
-        if self.proxy.is_some() {
-            if self.proxy.as_ref().unwrap().starts_with("socks4") {
-                eprintln!("Error: Socks4 proxy is not supported by reqwest.");
-                std::process::exit(1);
-            }
-            let proxy = Proxy::all(self.proxy.as_ref().unwrap());
-            if proxy.is_err() {
-                eprintln!("Error: Invalid proxy URL: {}", self.proxy.as_ref().unwrap());
-                std::process::exit(1);
-            }
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-struct ResponseStats {
-    duration: std::time::Duration,
-    status_code: Option<reqwest::StatusCode>,
-    content_length: Option<u64>,
-    partial_response: Option<String>,
-    dns_times: Option<(std::time::Duration, std::time::Duration)>,
-    cache_status: Option<CacheStatus>,
-}
+mod utils;
 
 #[derive(Debug, Clone)]
 struct Sent {
     count: usize,
 }
 
-// Add custom error type
 #[derive(Debug)]
 enum PepeError {
     HeaderParseError(String),
@@ -219,255 +48,73 @@ impl std::fmt::Display for PepeError {
 
 impl std::error::Error for PepeError {}
 
-// Compute dns resolution time, dns lookup time
-async fn resolve_dns(url: &str) -> Result<(std::time::Duration, std::time::Duration), PepeError> {
-    let uri = Uri::from_str(url).map_err(|e| PepeError::UrlParseError(e))?;
-    let host = uri.host().ok_or_else(|| PepeError::HostParseError)?;
-
+async fn handle_request(
+    client: Arc<reqwest::Client>,
+    url: String,
+    method: String,
+    body: Option<String>,
+    tx: mpsc::Sender<ResponseStats>,
+    sent_tx: mpsc::Sender<Sent>,
+    permit: tokio::sync::OwnedSemaphorePermit,
+) {
     let start = std::time::Instant::now();
-    let addrs = match tokio::net::lookup_host(format!("{}:0", host)).await {
-        Ok(addrs) => addrs,
-        Err(e) => {
-            // eprintln!("DNS lookup failed for host {}: {}", host, e);
-            return Err(PepeError::IoError(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                e,
-            )));
-        }
+    let method = reqwest::Method::from_bytes(method.as_bytes()).unwrap_or(reqwest::Method::GET);
+
+    let _ = sent_tx.send(Sent { count: 1 }).await;
+
+    let dns_times = resolve_dns(&url).await.unwrap_or_default();
+
+    let response = if method == reqwest::Method::POST && body.is_some() {
+        client
+            .request(method, &url)
+            .body(body.unwrap())
+            .send()
+            .await
+    } else {
+        client.request(method, &url).send().await
     };
-    let dns_lookup_time = start.elapsed();
 
-    let start = std::time::Instant::now();
-    let _ = addrs.collect::<Vec<_>>();
-    let dns_resolution_time = start.elapsed();
+    let stats = ResponseStats::from_response(response, start, dns_times).await;
 
-    Ok((dns_lookup_time, dns_resolution_time))
+    drop(permit);
+    let _ = tx.send(stats).await;
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub enum CacheStatus {
-    Hit,
-    Miss,
-    Stale,
-    Expired,
-    Revalidated,
-    Bypass,
-    Dynamic,
-    Error,
-    Unknown,
-}
-
-#[derive(Hash, Debug, PartialEq, Eq, Clone)]
-pub enum CacheCategory {
-    Hit,
-    Miss,
-    Unknown,
-}
-
-impl CacheCategory {
-    pub fn from_cache_status(status: &CacheStatus) -> CacheCategory {
-        match status {
-            CacheStatus::Hit | CacheStatus::Revalidated | CacheStatus::Stale => CacheCategory::Hit,
-            CacheStatus::Miss
-            | CacheStatus::Expired
-            | CacheStatus::Bypass
-            | CacheStatus::Dynamic => CacheCategory::Miss,
-            CacheStatus::Error | CacheStatus::Unknown => CacheCategory::Unknown,
-        }
-    }
-}
-
-impl CacheStatus {
-    // Parse a cache status string into the CacheStatus enum
-    pub fn from_str(status: &str) -> CacheStatus {
-        match status.to_lowercase().as_str() {
-            "hit" => CacheStatus::Hit,
-            "miss" => CacheStatus::Miss,
-            "stale" => CacheStatus::Stale,
-            "expired" => CacheStatus::Expired,
-            "revalidated" => CacheStatus::Revalidated,
-            "bypass" => CacheStatus::Bypass,
-            "dynamic" => CacheStatus::Dynamic,
-            "error" => CacheStatus::Error,
-            _ => CacheStatus::Unknown,
-        }
-    }
-}
-
-/// Function to parse cache status from `reqwest` headers
-pub fn parse_cache_status(headers: &HeaderMap) -> Option<CacheStatus> {
-    let cache_headers = [
-        "x-cache",
-        "x-cache-status",
-        "cf-cache-status",
-        "x-cache-lookup",
-        "x-cdn-cache-status",
-        "x-backend-cache-status",
-        "x-vercel-cache",
-    ];
-
-    for header in cache_headers {
-        if let Some(value) = headers.get(header) {
-            if let Ok(value_str) = value.to_str() {
-                return Some(CacheStatus::from_str(value_str));
-            }
-        }
-    }
-
-    None
-}
-
-// Modified request headers handling
-async fn run(
-    args: &Args,
+async fn run_request(
+    args: &Cli,
     tx: mpsc::Sender<ResponseStats>,
     sent_tx: mpsc::Sender<Sent>,
 ) -> Result<(Vec<ResponseStats>, std::time::Duration), PepeError> {
-    let mut request_headers = reqwest::header::HeaderMap::new();
-
-    // Add user agent
-    request_headers.insert(
-        USER_AGENT,
-        args.user_agent
-            .parse::<reqwest::header::HeaderValue>()
-            .map_err(|e| PepeError::HeaderParseError(e.to_string()))?,
-    );
-
-    // Parse headers safely
-    for header in &args.headers {
-        let parts: Vec<&str> = header.splitn(2, ':').collect();
-        if parts.len() == 2 {
-            let name = reqwest::header::HeaderName::from_bytes(parts[0].trim().as_bytes())
-                .map_err(|e| PepeError::HeaderParseError(e.to_string()))?;
-            let value = reqwest::header::HeaderValue::from_str(parts[1].trim())
-                .map_err(|e| PepeError::HeaderParseError(e.to_string()))?;
-            request_headers.insert(name, value);
-        }
-    }
-
-    let semaphore = Arc::new(Semaphore::new(args.concurrency as usize));
-    let mut client_builder = reqwest::Client::builder()
-        .default_headers(request_headers)
-        .timeout(std::time::Duration::from_secs(args.timeout as u64));
-
-    if let Some(proxy_url) = &args.proxy {
-        let proxy =
-            Proxy::all(proxy_url).map_err(|e| PepeError::HeaderParseError(e.to_string()))?;
-        client_builder = client_builder.proxy(proxy);
-    }
-
-    if args.disable_compression {
-        client_builder = client_builder.no_gzip();
-    }
-
-    if args.disable_keepalive {
-        client_builder = client_builder.connection_verbose(true);
-    }
-
-    if args.disable_redirects {
-        client_builder = client_builder.redirect(reqwest::redirect::Policy::none());
-    }
-
-    client_builder = client_builder.timeout(std::time::Duration::from_secs(args.timeout as u64));
-
-    let client = Arc::new(
-        client_builder
-            .build()
-            .map_err(|e| PepeError::RequestError(e))?,
-    );
+    let client = Arc::new(args.build_client()?);
     let all_start = std::time::Instant::now();
+    let semaphore = Arc::new(Semaphore::new(args.concurrency as usize));
 
-    // Spawn request handler
     let handler = tokio::spawn({
         let client = client.clone();
-        let args = args.clone();
+        let tx = tx;
+        let sent_tx = sent_tx;
+        let url = args.url.clone();
+        let method = args.method.clone();
+        let body = args.body.clone();
+        let number = args.number;
+
         async move {
-            for _i in 0..args.number {
-                let sem = semaphore.clone();
-                let tx = tx.clone();
-                let permit = sem.acquire_owned().await.expect("Semaphore acquire failed");
-                let client = client.clone();
-                let url = args.url.clone();
-                let method = args.method.clone();
-                let body = args.body.clone();
+            for _ in 0..number {
+                let semaphore = semaphore.clone();
+                let permit = semaphore
+                    .acquire_owned()
+                    .await
+                    .expect("Semaphore acquire failed");
 
-                let sent_tx = sent_tx.clone();
-
-                tokio::spawn(async move {
-                    let start = std::time::Instant::now();
-                    let method = reqwest::Method::from_bytes(method.as_bytes())
-                        .unwrap_or(reqwest::Method::GET);
-
-                    // Send a message to the sent channel that a request has been sent
-                    let _ = sent_tx.send(Sent { count: 1 }).await;
-
-                    // Compute dns resolution time, dns lookup time
-                    let dns_times: (std::time::Duration, std::time::Duration) =
-                        resolve_dns(&url).await.unwrap_or_default();
-
-                    // if post and body is not empty then send post request
-                    let response = if method == reqwest::Method::POST && body.is_some() {
-                        client
-                            .request(method, &url)
-                            .body(body.unwrap())
-                            .send()
-                            .await
-                    } else {
-                        client.request(method, &url).send().await
-                    };
-
-                    let response_headers = response
-                        .as_ref()
-                        .map(|r| r.headers().clone())
-                        .unwrap_or_default();
-
-                    // Parse cache status
-                    let cache_status = parse_cache_status(&response_headers);
-
-                    let stats = match response {
-                        Ok(resp) => {
-                            let status_code = resp.status();
-                            let content_length = resp.content_length();
-                            let text = resp.text().await.unwrap_or_default();
-                            let text = text.trim().replace("\n", " ").replace("\r", " ");
-                            let truncated_text = if text.len() > 100 {
-                                text[..100].to_string()
-                            } else {
-                                text
-                            };
-
-                            ResponseStats {
-                                duration: start.elapsed(),
-                                status_code: Some(status_code),
-                                content_length,
-                                partial_response: Some(truncated_text),
-                                dns_times: Some(dns_times),
-                                cache_status,
-                            }
-                        }
-                        Err(e) => {
-                            // Capture timeout errors
-                            let status_code = e.status();
-                            let content_length = None;
-                            let partial_response = None;
-                            ResponseStats {
-                                duration: start.elapsed(),
-                                status_code,
-                                content_length,
-                                partial_response,
-                                dns_times: Some(dns_times),
-                                cache_status,
-                            }
-                        }
-                    };
-
-                    drop(permit);
-                    if tx.send(stats).await.is_err() {
-                        Ok::<(), ()>(())
-                    } else {
-                        Ok(())
-                    }
-                });
+                tokio::spawn(handle_request(
+                    client.clone(),
+                    url.clone(),
+                    method.clone(),
+                    body.clone(),
+                    tx.clone(),
+                    sent_tx.clone(),
+                    permit,
+                ));
             }
         }
     });
@@ -484,8 +131,12 @@ async fn run(
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut args = Args::parse();
-    args.validate();
+    let mut args = Cli::parse();
+
+    if let Err(e) = args.validate() {
+        eprintln!("{}", e);
+        std::process::exit(1);
+    }
 
     enable_raw_mode()?;
     let mut stdout = stdout();
@@ -498,7 +149,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let handler = tokio::spawn({
             let args = args.clone();
-            async move { run(&args, tx, sent_tx).await }
+            async move { run_request(&args.clone(), tx, sent_tx).await }
         });
 
         let mut dashboard = ui::Dashboard::new(args.clone());

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,0 +1,77 @@
+use crate::cache::CacheStatus;
+
+#[derive(Debug, Clone)]
+pub struct ResponseStats {
+    pub duration: std::time::Duration,
+    pub status_code: Option<reqwest::StatusCode>,
+    pub content_length: Option<u64>,
+    pub partial_response: Option<String>,
+    pub dns_times: Option<(std::time::Duration, std::time::Duration)>,
+    pub cache_status: Option<CacheStatus>,
+}
+
+impl Default for ResponseStats {
+    fn default() -> Self {
+        Self {
+            duration: std::time::Duration::default(),
+            status_code: None,
+            content_length: None,
+            partial_response: None,
+            dns_times: None,
+            cache_status: None,
+        }
+    }
+}
+
+impl ResponseStats {
+    pub async fn from_response(
+        resp: Result<reqwest::Response, reqwest::Error>,
+        start: std::time::Instant,
+        dns_times: (std::time::Duration, std::time::Duration),
+    ) -> Self {
+        let response_headers = resp
+            .as_ref()
+            .map(|r| r.headers().clone())
+            .unwrap_or_default();
+
+        let cache_status = CacheStatus::parse_headers(&response_headers);
+        let stats = match resp {
+            Ok(resp) => {
+                let status_code = resp.status();
+                let content_length = resp.content_length();
+                let text = resp.text().await.unwrap_or_default();
+                let text = text.trim().replace("\n", " ").replace("\r", " ");
+                let truncated_text = if text.len() > 100 {
+                    text[..100].to_string()
+                } else {
+                    text
+                };
+
+                ResponseStats {
+                    duration: start.elapsed(),
+                    status_code: Some(status_code),
+                    content_length,
+                    partial_response: Some(truncated_text),
+                    dns_times: None,
+                    cache_status,
+                }
+            }
+            Err(e) => {
+                // Capture timeout errors
+                let status_code = e.status();
+                let content_length = None;
+                let partial_response = None;
+                ResponseStats {
+                    duration: start.elapsed(),
+                    status_code,
+                    content_length,
+                    partial_response,
+                    dns_times: Some(dns_times),
+                    cache_status,
+                }
+            }
+        };
+
+        stats
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4,24 +4,24 @@ use crossterm::{
     event::{self, Event, KeyCode},
     terminal::enable_raw_mode,
 };
+use ratatui::widgets::ListItem;
 use ratatui::{
     backend::CrosstermBackend,
     layout::{Constraint, Direction, Layout, Rect},
     widgets::{BarChart, BarGroup, Block, Borders, List, Paragraph},
     Frame, Terminal,
 };
-use reqwest::StatusCode;
-use std::thread::available_parallelism;
-use tokio::sync::mpsc;
-
-use crate::{Args, CacheCategory, ResponseStats, Sent};
-
 use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
 };
+use reqwest::StatusCode;
+use std::thread::available_parallelism;
+use tokio::sync::mpsc;
 
-use ratatui::widgets::ListItem;
+use crate::cache::CacheCategory;
+use crate::{Cli, Sent};
+use crate::ResponseStats;
 
 const LOGO: &str = r#"
     ██████╗ ███████╗██████╗ ███████╗
@@ -51,12 +51,11 @@ struct Stats {
     cache_categories: HashMap<CacheCategory, usize>,
 }
 pub struct Dashboard {
-    // Add storage fields to hold the strings and data
     label_storage: Vec<String>,
     bar_chart_data: Vec<(String, u64)>,
     histogram: Vec<(String, u64)>,
     requests: Vec<ResponseStats>,
-    args: Args,
+    args: Cli,
     status_codes: HashMap<StatusCode, usize>,
     stats: Stats,
     elapsed: std::time::Instant,
@@ -141,7 +140,7 @@ impl Dashboard {
         }
     }
 
-    pub fn new(args: Args) -> Self {
+    pub fn new(args: Cli) -> Self {
         Self {
             bar_chart_data: Vec::new(),
             histogram: Vec::new(),
@@ -248,7 +247,10 @@ impl Dashboard {
                     Style::default().fg(Color::Magenta),
                 ),
                 Span::raw(" "),
-                Span::styled(format!("{:?}", self.args.url), Style::default().fg(Color::White)),
+                Span::styled(
+                    format!("{:?}", self.args.url),
+                    Style::default().fg(Color::White),
+                ),
             ]));
         }
 
@@ -278,7 +280,10 @@ impl Dashboard {
                 Style::default().fg(Color::Magenta),
             ),
             Span::raw(" "),
-            Span::styled(format!("{:?}", self.args.url), Style::default().fg(Color::White)),
+            Span::styled(
+                format!("{:?}", self.args.url),
+                Style::default().fg(Color::White),
+            ),
         ]))
     }
 
@@ -491,7 +496,7 @@ impl Dashboard {
             " ".repeat(bar_width - filled),
             percent
         );
-        if self.stats.count == (self.args.number as usize)  && self.final_duration.is_none() {
+        if self.stats.count == (self.args.number as usize) && self.final_duration.is_none() {
             self.final_duration = Some(std::time::Instant::now() - self.elapsed);
         }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,63 @@
+use std::{num::NonZeroUsize, thread::available_parallelism};
+
+use hyper::Uri;
+use std::str::FromStr;
+
+use crate::PepeError;
+
+/// Get the number of available cores
+/// If the number of cores is not available, return 8
+pub fn num_of_cores() -> u32 {
+    available_parallelism()
+        .unwrap_or(NonZeroUsize::new(8).unwrap())
+        .get() as u32
+}
+
+/// Get the version of the application
+/// This is the version from Cargo.toml
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+/// Get the default user agent string
+/// This is the user agent string used by pepe by default
+/// It includes the version of the application
+/// e.g. pepe/0.1.0
+pub fn default_user_agent() -> String {
+    format!("pepe/{}", version())
+}
+
+/// Resolve the DNS for a given URL
+/// This function takes a URL string and returns a tuple of two durations
+/// The first duration is the time taken to lookup the DNS
+/// The second duration is the time taken to resolve the DNS
+/// If the DNS lookup fails, an error is returned
+/// # Arguments
+/// * `url` - A string slice that holds the URL
+/// # Returns
+/// A Result containing a tuple of two durations or an error
+pub async fn resolve_dns(
+    url: &str,
+) -> Result<(std::time::Duration, std::time::Duration), PepeError> {
+    let uri = Uri::from_str(url).map_err(|e| PepeError::UrlParseError(e))?;
+    let host = uri.host().ok_or_else(|| PepeError::HostParseError)?;
+
+    let start = std::time::Instant::now();
+    let addrs = match tokio::net::lookup_host(format!("{}:0", host)).await {
+        Ok(addrs) => addrs,
+        Err(e) => {
+            // eprintln!("DNS lookup failed for host {}: {}", host, e);
+            return Err(PepeError::IoError(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                e,
+            )));
+        }
+    };
+    let dns_lookup_time = start.elapsed();
+
+    let start = std::time::Instant::now();
+    let _ = addrs.collect::<Vec<_>>();
+    let dns_resolution_time = start.elapsed();
+
+    Ok((dns_lookup_time, dns_resolution_time))
+}


### PR DESCRIPTION
Generate a reqwest client from the cli

Remove redundant comments

Improve event handling structure

Break large functions into smaller ones

Prefer default_value_t instead of default_value

Remove redundant short and long attributes when inferred in clap

Replace #[clap] with #[arg]

Improve validation by returning an error instead of exiting the app

Thanks to #13 